### PR TITLE
Implement basic court case search demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # finalproject_test
+
+This repository contains a minimal example of a court case search system. The
+`case_search` package includes a sample dataset and a command line interface for
+searching cases by case number.
+
+## Quick start
+
+```bash
+python -m case_search.search 105訴123
+```
+
+This will print out the matching case information from the sample dataset.
+
+This demo provides the basic structure for the search system described in the
+project proposal. Future work includes NLP processing of judgment text,
+automated data collection, and a more advanced query interface.

--- a/case_search/data/sample_cases.json
+++ b/case_search/data/sample_cases.json
@@ -1,0 +1,22 @@
+[
+  {
+    "case_number": "105訴123",
+    "court": "臺灣新竹地方法院",
+    "plaintiff": "張三",
+    "defendant": "李四",
+    "lawyer": "王律師",
+    "summary": "原告請求被告返還借款。",
+    "result": "原告之訴駁回。",
+    "full_text": "本院判決如下..."
+  },
+  {
+    "case_number": "105訴124",
+    "court": "臺灣臺北地方法院",
+    "plaintiff": "王五",
+    "defendant": "陳六",
+    "lawyer": "林律師",
+    "summary": "契約糾紛案。",
+    "result": "被告應給付原告新台幣十萬元。",
+    "full_text": "判決全文..."
+  }
+]

--- a/case_search/search.py
+++ b/case_search/search.py
@@ -1,0 +1,52 @@
+"""
+Simple court case searcher demo.
+
+TODO: Implement NLP-based role extraction, web scraping for automatic data updates,
+and advanced filtering as described in the project specification.
+"""
+import json
+import argparse
+from pathlib import Path
+from typing import List, Dict
+
+
+DATA_PATH = Path(__file__).resolve().parent / "data" / "sample_cases.json"
+
+
+class CaseSearcher:
+    def __init__(self, data_file: Path = DATA_PATH):
+        with data_file.open("r", encoding="utf-8") as f:
+            self.cases: List[Dict] = json.load(f)
+
+    def search_by_case_number(self, keyword: str) -> List[Dict]:
+        """Return cases where case_number exactly matches the keyword."""
+        return [c for c in self.cases if c["case_number"] == keyword]
+
+    def highlight(self, text: str, keyword: str) -> str:
+        return text.replace(keyword, f"**{keyword}**")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple case searcher")
+    parser.add_argument("keyword", help="Case number to search for")
+    args = parser.parse_args()
+
+    searcher = CaseSearcher()
+    results = searcher.search_by_case_number(args.keyword)
+
+    if not results:
+        print("No cases found")
+        return
+
+    for case in results:
+        print(f"Case Number: {case['case_number']}")
+        print(f"Court: {case['court']}")
+        print(f"Plaintiff: {case['plaintiff']}")
+        print(f"Defendant: {case['defendant']}")
+        print(f"Summary: {case['summary']}")
+        print(f"Result: {case['result']}")
+        print("---")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a demo `case_search` package
- provide a sample dataset of cases
- implement a simple CLI searcher for case number lookup
- document quick start usage
- remove compiled bytecode and set up `.gitignore`

## Testing
- `python -m case_search.search 105訴123`

------
https://chatgpt.com/codex/tasks/task_e_6845d5d58cec8323a627b1f4b80f6886